### PR TITLE
Add hardened .npmrc for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Supply-chain hardening directives
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+# engine-strict=true  # disabled: hard-fails `npm ci` on Node 18.20.7 — the repo overrides field pins serialize-javascript@7.0.5 (engines node>=20.0.0), which breaks Cypress-14-supported Node 18. Re-enable only after the serialize-javascript override is constrained to a Node-18-compatible line or Node 18 is officially dropped.
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
Adds a hardened `.npmrc` enforcing npm supply-chain best practices:

```ini
ignore-scripts=true
strict-ssl=true
save-exact=true
# engine-strict=true  (disabled — see notes)
legacy-peer-deps=false
audit-level=high
```

Notes:
- `ignore-scripts=true` skips Cypress's postinstall binary download. Cloud runs via `browserstack-cypress` are unaffected; for local Cypress runs, execute `npx cypress install` once after `npm install`.
- `engine-strict` is commented out because the `serialize-javascript` override requires Node >=20 while this sample supports Node 18; it can be enabled once that floor changes.
- Verified: `npm ci` against the committed package-lock.json on Node 18, 20, and 22 — lockfile unchanged; sample test run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
